### PR TITLE
Bind correct context for Ext.Logger.log

### DIFF
--- a/src/coffee/Deft/log/Logger.coffee
+++ b/src/coffee/Deft/log/Logger.coffee
@@ -6,42 +6,42 @@ Open source under the [MIT License](http://en.wikipedia.org/wiki/MIT_License).
 Ext.define( 'Deft.log.Logger',
 	alternateClassName: [ 'Deft.Logger' ]
 	singleton: true
-	
+
 	log: ( message, priority ) ->
 		return
-	
+
 	error: ( message ) ->
 		@log( message, 'error' )
 		return
-	
+
 	info: ( message ) ->
 		@log( message, 'info' )
 		return
-	
+
 	verbose: ( message ) ->
 		@log( message, 'verbose' )
 		return
-	
+
 	warn: ( message ) ->
 		@log( message, 'warn' )
 		return
-		
+
 	deprecate: ( message ) ->
 		@log( message, 'deprecate' )
 		return
 ,
 	->
 		if Ext.isFunction( Ext.Logger?.log )
-			@log = Ext.Logger.log
+			@log = Ext.bind(Ext.Logger.log, Ext.Logger)
 		else if Ext.isFunction( Ext.log )
 			@log = ( message, priority = 'info' ) ->
 				if priority is 'deprecate'
-					priority = 'warn' 
+					priority = 'warn'
 				Ext.log(
 					msg: message
 					level: priority
 				)
 				return
-		
+
 		return
 )


### PR DESCRIPTION
With Sencha Touch 2.0.1 without this fix the value of `this` when Ext.Logger.log is called is incorrect. Causes `if (!this.getEnabled())` on line 61 of Ext.log.Logger to fail with an undefined is not a function error.
