### PR TITLE
Add support of addListener options (buffer, delay, scope, etc.) to Observer

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -46,6 +46,7 @@
 				<file name="Deft/ioc/DependencyProvider.js" />
 				<file name="Deft/ioc/Injector.js" />
 				<file name="Deft/mixin/Injectable.js" />
+                <file name="Deft/util/Object.js" />
 				<file name="Deft/mvc/Observer.js" />
 				<file name="Deft/mvc/ComponentSelectorListener.js" />
 				<file name="Deft/mvc/ComponentSelector.js" />

--- a/src/coffee/Deft/mvc/Observer.coffee
+++ b/src/coffee/Deft/mvc/Observer.coffee
@@ -112,14 +112,15 @@ Ext.define( 'Deft.mvc.Observer',
 					scope = host
 
 					# If the handler is a configuration object, parse it and use those values to create the Observer.
-					if( Ext.isObject( handler ) )
-						eventName = handler.event if handler?.event
-						handler = handler.fn if handler?.fn
-						scope = handler.scope if handler?.scope
+					options = Ext.isObject( handler ) ? handler : null
+					if( options )
+						eventName = Deft.Object.extract( options, 'event' ) if options.event
+						handler = Deft.Object.extract( options, 'fn' ) if options.fn
+						scope = Deft.Object.extract( options, 'scope' ) if options.scope
 
 					references = @locateReferences( host, target, handler )
 					if references
-						references.target.on( eventName, references.handler, host )
+						references.target.on( eventName, references.handler, scope, options )
 						@listeners.push( { targetName: target, target: references.target, event: eventName, handler: references.handler, scope: scope } )
 						Deft.Logger.log( "Created observer on '#{ target }' for event '#{ eventName }'." )
 					else

--- a/src/coffee/Deft/util/Object.coffee
+++ b/src/coffee/Deft/util/Object.coffee
@@ -1,0 +1,15 @@
+###*
+* Common utility functions used by DeftJS.
+###
+Ext.define( 'Deft.util.Object',
+	alternateClassName: [ 'Deft.Object' ]
+
+	statics:
+		###*
+		* Retrieves value for specified key and deletes the pair
+		###
+		extract: ( object, key ) ->
+			value = object[key]
+			delete object[key]
+			return value
+)


### PR DESCRIPTION
Change to make Observer listeners support additional options.

``` coffeescript
observer:
  messageBus:
    thingshappened: [
      {
        fn: 'makeItHappen'
        buffer: 75
      }
      {
        fn: 'logIt'
        scope: @getSomeOtherScope()
      }
    ]
```
