### PR TITLE
Prevent unnecessary cloning of config objects.

### DIFF
--- a/packages/deft/src/coffee/ioc/Injector.coffee
+++ b/packages/deft/src/coffee/ioc/Injector.coffee
@@ -253,7 +253,7 @@ Ext.define( 'Deft.ioc.Injector',
 				# Ext JS 4.0
 				Ext.Component.override(
 					constructor: ( config ) ->
-						config = Ext.Object.merge( {}, config or {}, @injectConfig or {} )
+						config = Ext.apply(config or {}, @injectConfig)
 						delete @injectConfig
 						return @callOverridden( [ config ] )
 				)
@@ -263,7 +263,7 @@ Ext.define( 'Deft.ioc.Injector',
 					override: 'Ext.Component'
 
 					constructor: ( config ) ->
-						config = Ext.Object.merge( {}, config or {}, @injectConfig or {} )
+						config = Ext.apply(config or {}, @injectConfig)
 						delete @injectConfig
 						return @callParent( [ config ] )
 				)


### PR DESCRIPTION
I was having problems with `"Maximum call stack size exceeded."` errors when initializing components whose config properties may reference larger objects. For some reason those objects would get cloned instead of just referenced. I think the reason is the usage of Ext.Object.merge as shown in this PR merging this.injectConfig and this.config onto a whole new object. Errors are gone now.

I tried to check this PR via Travis but was unable to get the test suite running.
